### PR TITLE
Drop UI tool selection; tailor Slack messages per scan outcome

### DIFF
--- a/api/notifications.py
+++ b/api/notifications.py
@@ -1,0 +1,165 @@
+"""Outbound notifications for scan lifecycle events.
+
+Connector credentials (Slack webhook URL, etc.) live server-side in the
+``connectors`` table and are read here at send time. Nothing in this module
+raises on failure — a broken webhook must never break a scan result.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, Optional
+
+import httpx
+
+from storage.repository import StorageRepository
+
+logger = logging.getLogger(__name__)
+
+# Transient errors (DNS blips, connection resets) are common right after a
+# runtime/dynamic scan churns Docker's embedded DNS. Retry a few times so a
+# momentary blip never loses the notification.
+_MAX_ATTEMPTS = 3
+_RETRY_BACKOFF_SECONDS = 2.0
+
+# Per-status header (emoji + title + short subtitle). Different shapes for
+# different outcomes so on-call can triage from the notification alone.
+_STATUS_HEADERS = {
+    "completed": ("✅", "VulnReach scan complete", "No policy-blocking findings."),
+    "blocked":   ("⛔", "VulnReach policy gate: BLOCK", "Reachable findings matched a block_if rule."),
+    "partial":   ("⚠️", "VulnReach scan partial", "Some tools did not contribute — coverage degraded."),
+    "failed":    ("❌", "VulnReach scan failed", "A required tool failed; results are unreliable."),
+    "cancelled": ("🚫", "VulnReach scan cancelled", "Stopped before completion."),
+    "timeout":   ("⏱️", "VulnReach scan timed out", "Scan exceeded its execution budget."),
+    "error":     ("💥", "VulnReach scan error", "Unhandled exception during scan."),
+}
+
+
+class SlackNotifier:
+    def __init__(self, storage: StorageRepository) -> None:
+        self.storage = storage
+
+    async def notify_scan_complete(
+        self,
+        scan_id: str,
+        status: str,
+        summary: Dict[str, Any],
+        repo: str,
+        pipeline_status: Optional[str] = None,
+        failed_tools: Optional[list] = None,
+        fatal_tools: Optional[list] = None,
+        error: Optional[str] = None,
+    ) -> bool:
+        """Post a scan-outcome message to the configured Slack webhook.
+
+        Message shape varies by ``status`` (completed / blocked / partial /
+        failed / cancelled / timeout / error). Returns True if delivered,
+        False otherwise. Never raises.
+        """
+        try:
+            cfg = self.storage.get_connector("slack") or {}
+            webhook_url = cfg.get("webhook_url")
+            if not webhook_url:
+                logger.info("slack notify skipped — connector not configured (scan_id=%s)", scan_id)
+                return False
+
+            text = self._format_message(
+                scan_id, status, summary, repo, pipeline_status,
+                failed_tools or [], fatal_tools or [], error,
+            )
+            payload: Dict[str, Any] = {"text": text}
+            if cfg.get("channel"):
+                payload["channel"] = cfg["channel"]
+
+            last_err: Optional[str] = None
+            for attempt in range(1, _MAX_ATTEMPTS + 1):
+                try:
+                    async with httpx.AsyncClient(timeout=10) as client:
+                        resp = await client.post(webhook_url, json=payload)
+                except httpx.RequestError as exc:
+                    # Network-level failure (DNS, connect, timeout) — retry.
+                    last_err = f"{type(exc).__name__}: {exc}"
+                    logger.warning(
+                        "slack notify transient error attempt %d/%d (scan_id=%s): %s",
+                        attempt, _MAX_ATTEMPTS, scan_id, last_err,
+                    )
+                    if attempt < _MAX_ATTEMPTS:
+                        await asyncio.sleep(_RETRY_BACKOFF_SECONDS * attempt)
+                    continue
+
+                if resp.status_code == 200:
+                    logger.info("slack notify sent (scan_id=%s status=%s)", scan_id, status)
+                    return True
+
+                # HTTP-level failure from Slack — do not retry (bad payload/URL).
+                logger.warning(
+                    "slack notify failed — status=%s body=%s (scan_id=%s)",
+                    resp.status_code, resp.text[:200], scan_id,
+                )
+                return False
+
+            logger.warning(
+                "slack notify gave up after %d attempts (scan_id=%s): %s",
+                _MAX_ATTEMPTS, scan_id, last_err,
+            )
+            return False
+        except Exception as exc:  # never let a notification failure break a scan
+            logger.warning("slack notify error (scan_id=%s): %s", scan_id, exc)
+            return False
+
+    @staticmethod
+    def _format_message(
+        scan_id: str,
+        status: str,
+        summary: Dict[str, Any],
+        repo: str,
+        pipeline_status: Optional[str],
+        failed_tools: list,
+        fatal_tools: list,
+        error: Optional[str],
+    ) -> str:
+        emoji, title, subtitle = _STATUS_HEADERS.get(
+            status, ("•", f"VulnReach scan {status}", "")
+        )
+        dyn = summary.get("dynamically_reachable", 0) or 0
+        stat = summary.get("statically_reachable", 0) or 0
+        reachable = dyn + stat
+
+        # Common header
+        lines = [f"{emoji} *{title}*"]
+        if subtitle:
+            lines.append(f"_{subtitle}_")
+        lines.append(f"• Repo: `{repo or 'unknown'}`")
+        lines.append(f"• Scan ID: `{scan_id}`")
+
+        # Per-status body
+        if status in ("completed", "blocked", "partial"):
+            lines.append(
+                f"• Reachable findings: *{reachable}* "
+                f"(dynamic: {dyn}, static: {stat})"
+            )
+            if pipeline_status:
+                lines.append(f"• Policy gate: *{pipeline_status}*")
+            if status == "partial" and failed_tools:
+                lines.append(f"• Degraded tools: {', '.join(failed_tools)}")
+
+        elif status == "failed":
+            if fatal_tools:
+                lines.append(f"• Fatal tool(s): *{', '.join(fatal_tools)}*")
+            if failed_tools:
+                lines.append(f"• Other failures: {', '.join(failed_tools)}")
+            if error:
+                lines.append(f"• Error: `{error[:200]}`")
+
+        elif status in ("timeout", "error"):
+            if error:
+                lines.append(f"• Detail: `{error[:200]}`")
+            if failed_tools or fatal_tools:
+                lines.append(
+                    f"• Tools impacted: {', '.join(fatal_tools + failed_tools)}"
+                )
+
+        elif status == "cancelled":
+            if error:  # carries cancellation reason if provided
+                lines.append(f"• Reason: {error[:200]}")
+
+        return "\n".join(lines)

--- a/api/server.py
+++ b/api/server.py
@@ -12,7 +12,8 @@ import asyncio
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
+import re as _re
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.util import get_remote_address
@@ -24,6 +25,7 @@ from api.auth import (
     create_token,
     hash_api_key,
     hash_password,
+    require_admin,
     require_user,
     set_api_key_validator,
     verify_api_key,
@@ -320,8 +322,11 @@ async def start_scan(
     else:
         config = default_config()
 
-    requested_tools = payload.get("tools")
-    tools = list(requested_tools if requested_tools else (config.scan.tools or []))
+    # Tools are no longer selected from the UI — they come from the resolved
+    # config (an explicit config_path, or default_config for URL scans). For URL
+    # scans the git agent later auto-discovers the repo's vulnreach.yaml and the
+    # runner re-resolves tools from it; the stored metadata is refreshed then.
+    tools = list(config.scan.tools or [])
 
     # Auto-inject dynamic_reachability if runtime is enabled and not already present
     if config.scan.runtime.enabled and "dynamic_reachability" not in tools:
@@ -565,6 +570,197 @@ async def export_scan_pdf(scan_id: str, principal: UserPrincipal = Depends(requi
         media_type="application/pdf",
         headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
+
+
+# ── Connectors ──────────────────────────────────────────────────
+
+_ALLOWED_CONNECTORS = {"slack", "jira"}
+
+# Masks all stored secrets — nothing sensitive is ever returned to the browser.
+def _mask_connector(connector_id: str, cfg: dict) -> dict:
+    if connector_id == "slack":
+        return {
+            "connected": bool(cfg.get("webhook_url")),
+            "channel": cfg.get("channel", ""),
+        }
+    if connector_id == "jira":
+        return {
+            "connected": bool(cfg.get("api_token")),
+            "base_url": cfg.get("base_url", ""),
+            "email": cfg.get("email", ""),
+            "project_key": cfg.get("project_key", ""),
+        }
+    return {"connected": False}
+
+
+_HTTPS_RE = _re.compile(r'^https://', _re.IGNORECASE)
+
+
+class SlackConnectorRequest(BaseModel):
+    webhook_url: str
+    channel: str = ""
+
+    @field_validator("webhook_url")
+    @classmethod
+    def _validate_webhook(cls, v: str) -> str:
+        v = v.strip()
+        if len(v) > 500:
+            raise ValueError("webhook_url too long")
+        if not _HTTPS_RE.match(v):
+            raise ValueError("webhook_url must start with https://")
+        return v
+
+    @field_validator("channel")
+    @classmethod
+    def _validate_channel(cls, v: str) -> str:
+        v = v.strip()
+        if len(v) > 100:
+            raise ValueError("channel too long")
+        return v
+
+
+class JiraConnectorRequest(BaseModel):
+    base_url: str
+    email: str
+    api_token: str
+    project_key: str
+
+    @field_validator("base_url")
+    @classmethod
+    def _validate_base_url(cls, v: str) -> str:
+        v = v.strip().rstrip("/")
+        if len(v) > 256:
+            raise ValueError("base_url too long")
+        if not _HTTPS_RE.match(v):
+            raise ValueError("base_url must start with https://")
+        return v
+
+    @field_validator("email")
+    @classmethod
+    def _validate_email(cls, v: str) -> str:
+        v = v.strip()
+        if len(v) > 254:
+            raise ValueError("email too long")
+        if "@" not in v:
+            raise ValueError("email must contain @")
+        return v
+
+    @field_validator("api_token")
+    @classmethod
+    def _validate_token(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("api_token is required")
+        if len(v) > 500:
+            raise ValueError("api_token too long")
+        return v
+
+    @field_validator("project_key")
+    @classmethod
+    def _validate_project_key(cls, v: str) -> str:
+        v = v.strip().upper()
+        if not v:
+            raise ValueError("project_key is required")
+        if len(v) > 32:
+            raise ValueError("project_key too long")
+        if not _re.match(r'^[A-Z][A-Z0-9_]*$', v):
+            raise ValueError("project_key must be alphanumeric (e.g. SEC)")
+        return v
+
+
+@app.get("/connectors")
+async def list_connectors(principal: UserPrincipal = Depends(require_admin)):
+    result = {}
+    for cid in _ALLOWED_CONNECTORS:
+        cfg = storage.get_connector(cid) or {}
+        result[cid] = _mask_connector(cid, cfg)
+    return result
+
+
+@app.post("/connectors/slack")
+async def save_slack_connector(
+    body: SlackConnectorRequest,
+    principal: UserPrincipal = Depends(require_admin),
+):
+    cfg = {"webhook_url": body.webhook_url, "channel": body.channel}
+    storage.upsert_connector("slack", cfg)
+    _audit.info("connector_saved connector=slack user=%s", principal.username)
+    return _mask_connector("slack", cfg)
+
+
+@app.post("/connectors/jira")
+async def save_jira_connector(
+    body: JiraConnectorRequest,
+    principal: UserPrincipal = Depends(require_admin),
+):
+    cfg = {
+        "base_url": body.base_url,
+        "email": body.email,
+        "api_token": body.api_token,
+        "project_key": body.project_key,
+    }
+    storage.upsert_connector("jira", cfg)
+    _audit.info("connector_saved connector=jira user=%s", principal.username)
+    return _mask_connector("jira", cfg)
+
+
+@app.post("/connectors/{connector_id}/test")
+async def test_connector(
+    connector_id: str,
+    principal: UserPrincipal = Depends(require_admin),
+):
+    if connector_id not in _ALLOWED_CONNECTORS:
+        raise HTTPException(status_code=404, detail="Unknown connector")
+    cfg = storage.get_connector(connector_id)
+    if not cfg:
+        raise HTTPException(status_code=409, detail="Connector not configured")
+
+    import httpx
+
+    if connector_id == "slack":
+        webhook_url = cfg.get("webhook_url", "")
+        if not webhook_url:
+            raise HTTPException(status_code=409, detail="Connector not configured")
+        payload = {"text": "✅ VulnReach test message — Slack connector is working."}
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.post(webhook_url, json=payload)
+        if resp.status_code != 200:
+            raise HTTPException(status_code=502, detail=f"Slack returned {resp.status_code}")
+        _audit.info("connector_tested connector=slack user=%s", principal.username)
+        return {"ok": True}
+
+    if connector_id == "jira":
+        import base64
+        base_url  = cfg.get("base_url", "").rstrip("/")
+        email     = cfg.get("email", "")
+        api_token = cfg.get("api_token", "")
+        creds = base64.b64encode(f"{email}:{api_token}".encode()).decode()
+        headers = {
+            "Authorization": f"Basic {creds}",
+            "Accept": "application/json",
+        }
+        async with httpx.AsyncClient(timeout=10) as client:
+            resp = await client.get(f"{base_url}/rest/api/3/myself", headers=headers)
+        if resp.status_code == 401:
+            raise HTTPException(status_code=502, detail="Jira authentication failed — check email and API token")
+        if resp.status_code != 200:
+            raise HTTPException(status_code=502, detail=f"Jira returned {resp.status_code}")
+        _audit.info("connector_tested connector=jira user=%s", principal.username)
+        return {"ok": True}
+
+    raise HTTPException(status_code=404, detail="Unknown connector")
+
+
+@app.delete("/connectors/{connector_id}")
+async def delete_connector(
+    connector_id: str,
+    principal: UserPrincipal = Depends(require_admin),
+):
+    if connector_id not in _ALLOWED_CONNECTORS:
+        raise HTTPException(status_code=404, detail="Unknown connector")
+    storage.delete_connector(connector_id)
+    _audit.info("connector_deleted connector=%s user=%s", connector_id, principal.username)
+    return {"connector_id": connector_id, "deleted": True}
 
 
 # ── Public endpoints ─────────────────────────────────────────────

--- a/config/generic_scan.yml
+++ b/config/generic_scan.yml
@@ -45,3 +45,6 @@ policy:
       verdict: CONFIRMED
     - severity: HIGH
       verdict: CONFIRMED
+
+notifications:
+  slack: true

--- a/config/multitier_scan.yml
+++ b/config/multitier_scan.yml
@@ -38,3 +38,6 @@ policy:
       verdict: CONFIRMED
     - severity: HIGH
       verdict: CONFIRMED
+
+notifications:
+  slack: true

--- a/config/scan.sample.yml
+++ b/config/scan.sample.yml
@@ -58,3 +58,6 @@ policy:
   #   verdict: CONFIRMED
   # - severity: HIGH
   #   verdict: CONFIRMED
+
+notifications:
+  slack: true

--- a/config/scan.test.yml
+++ b/config/scan.test.yml
@@ -23,3 +23,6 @@ policy:
   block_if:
     - severity: CRITICAL
       verdict: CONFIRMED
+
+notifications:
+  slack: true

--- a/config/schema.py
+++ b/config/schema.py
@@ -78,6 +78,17 @@ class ScanSettings(BaseModel):
 
 
 
+class NotificationSettings(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # Per-connector toggle (opt-out). Defaults to on — every scan notifies the
+    # connector if it is configured under the Connectors page. Set to false to
+    # suppress. Credentials live server-side, never in this file. If the
+    # connector has no webhook configured, the notifier silently no-ops.
+    slack: bool = True
+    jira: bool = False
+
+
 class RiskSettings(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
@@ -108,6 +119,7 @@ class ScanConfig(BaseModel):
     scan: ScanSettings
     risk: RiskSettings = RiskSettings()
     policy: PolicySettings = PolicySettings()
+    notifications: NotificationSettings = NotificationSettings()
 
 
 def load_config(path: str) -> ScanConfig:

--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Any, Dict, Set, Tuple
 from urllib.parse import unquote
@@ -76,6 +77,58 @@ class Orchestrator:
         self.correlation_service = correlation_service
 
     async def execute_scan(
+        self,
+        scan_id: str,
+        repo_path: str,
+        config_path: str,
+        config: Any,
+        repo_url: str | None,
+    ) -> None:
+        try:
+            await self._execute_scan_inner(scan_id, repo_path, config_path, config, repo_url)
+        except asyncio.CancelledError:
+            # Surface user-initiated cancellation distinctly from failure.
+            self.storage.update_scan_status(scan_id, "cancelled")
+            logger.info("scan_cancelled", extra={"scan_id": scan_id})
+            await self._maybe_notify_failure(
+                scan_id, "cancelled", config, repo_url or repo_path,
+                error="Scan was cancelled before completion.",
+            )
+            raise
+        except asyncio.TimeoutError as exc:
+            self.storage.update_scan_status(scan_id, "failed")
+            logger.error("scan_timeout", extra={"scan_id": scan_id})
+            await self._maybe_notify_failure(
+                scan_id, "timeout", config, repo_url or repo_path, error=str(exc),
+            )
+        except Exception as exc:
+            self.storage.update_scan_status(scan_id, "failed")
+            logger.exception("scan_unhandled_error", extra={"scan_id": scan_id})
+            await self._maybe_notify_failure(
+                scan_id, "error", config, repo_url or repo_path,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+
+    async def _maybe_notify_failure(
+        self,
+        scan_id: str,
+        status: str,
+        config: Any,
+        repo: str,
+        error: str,
+    ) -> None:
+        if not (getattr(config, "notifications", None) and config.notifications.slack):
+            return
+        from api.notifications import SlackNotifier
+        await SlackNotifier(self.storage).notify_scan_complete(
+            scan_id=scan_id,
+            status=status,
+            summary={},
+            repo=repo,
+            error=error,
+        )
+
+    async def _execute_scan_inner(
         self,
         scan_id: str,
         repo_path: str,
@@ -338,3 +391,17 @@ class Orchestrator:
                 "fatal_tools": fatal_tools,
             },
         )
+
+        # Fire-and-forget notifications — gated by vulnreach.yaml notifications.*
+        # A failed notification must never affect the scan result.
+        if getattr(config, "notifications", None) and config.notifications.slack:
+            from api.notifications import SlackNotifier
+            await SlackNotifier(self.storage).notify_scan_complete(
+                scan_id=scan_id,
+                status=status,
+                summary=summary,
+                repo=repo_url or repo_path,
+                pipeline_status=correlation_output["pipeline_status"],
+                failed_tools=failed_tools,
+                fatal_tools=fatal_tools,
+            )

--- a/dashboard/dashboard.css
+++ b/dashboard/dashboard.css
@@ -1701,3 +1701,14 @@ body::after {
 .fixplan-upgrade .cur{color:var(--red)}.fixplan-upgrade .arr{color:var(--text-mute)}.fixplan-upgrade .next{color:var(--green)}
 .fixplan-cves{display:flex;flex-wrap:wrap;gap:.25rem;margin-bottom:.3rem}
 .fixplan-cve-label{font-size:.58rem;text-transform:uppercase;letter-spacing:.08em;color:var(--text-mute);margin-bottom:.2rem}
+
+/* ─── Connector badges ──────────────────────────────────────────────────── */
+.connector-badge{display:inline-block;font-size:.65rem;font-family:var(--mono);text-transform:uppercase;letter-spacing:.08em;padding:.2rem .55rem;border-radius:99px;border:1px solid;line-height:1.4}
+.connector-badge--connected{color:var(--green);border-color:var(--green);background:var(--green-dim)}
+.connector-badge--disconnected{color:var(--text-dim);border-color:var(--border);background:transparent}
+
+/* ─── Tool execution-state pills (scan overview) ────────────────────────── */
+.tool-state{display:inline-block;font-size:.62rem;font-family:var(--mono);padding:.15rem .45rem;border-radius:99px;border:1px solid;line-height:1.5;margin:.1rem .15rem .1rem 0;white-space:nowrap}
+.tool-state--ran{color:var(--green);border-color:var(--green);background:var(--green-dim)}
+.tool-state--skipped{color:var(--text-dim);border-color:var(--border);background:transparent}
+.tool-state--errored{color:var(--amber);border-color:#f5a62330;background:var(--amber-dim)}

--- a/dashboard/dashboard.js
+++ b/dashboard/dashboard.js
@@ -26,6 +26,7 @@ const PARTIALS = [
   ['_p-page-settings',  'partials/page-settings.html'],
   ['_p-page-inventory', 'partials/page-inventory.html'],
   ['_p-page-findings',  'partials/page-findings.html'],
+  ['_p-page-connectors','partials/page-connectors.html'],
   ['_p-panel',          'partials/panel-detail.html'],
   ['_p-modal-explain',  'partials/modal-explain.html'],
   ['_p-modal-graph',    'partials/modal-graph.html'],
@@ -171,7 +172,6 @@ function doLogout() {
 
 // ─── State ─────────────────────────────────────────────────────────────────
 let scans = [];
-let selectedTools = new Set(['trivy','tainter','python_reachability']);
 let currentScan = null;
 let currentTab = 'overview';
 let autoRefreshInterval = null;
@@ -263,7 +263,11 @@ policy:
   # - severity: CRITICAL
   #   verdict: CONFIRMED
   # - severity: HIGH
-  #   verdict: CONFIRMED`;
+  #   verdict: CONFIRMED
+
+notifications:
+  slack: true            # on by default — set false to suppress; no-op if connector unconfigured
+  jira: false            # (Jira ticket creation — not yet wired)`;
 
 function _hlYaml(raw) {
   return raw
@@ -591,7 +595,6 @@ async function copyLastApiKey() {
 // ─── Init ──────────────────────────────────────────────────────────────────
 async function initApp() {
   applyTheme(_theme);  // re-run now that #theme-btn exists in the DOM
-  buildToolChips();
   buildToolsPage();
   buildConfigPage();
   buildSettingsPage();
@@ -614,7 +617,7 @@ loadPartials().then(initApp).catch(err => {
 });
 
 // ─── Navigation ────────────────────────────────────────────────────────────
-const PAGES = ['scans','repo','new','tools','api','config','findings','settings','inventory'];
+const PAGES = ['scans','repo','new','tools','api','config','findings','settings','inventory','connectors'];
 
 function setPage(id) {
   PAGES.forEach(p => {
@@ -631,6 +634,7 @@ function setPage(id) {
   if (id === 'config') buildConfigPage();
   if (id === 'settings') buildSettingsPage();
   if (id === 'inventory') renderInventory();
+  if (id === 'connectors') initConnectors();
 }
 
 // ─── API helpers ───────────────────────────────────────────────────────────
@@ -1169,21 +1173,6 @@ function updateStats() {
   document.getElementById('stat-likely').textContent    = done.length ? likely    : '—';
 }
 
-// ─── Tool chips ────────────────────────────────────────────────────────────
-function buildToolChips() {
-  const wrap = document.getElementById('tool-chips');
-  wrap.innerHTML = Object.keys(TOOL_DEFS).map(t => `
-    <div class="tool-chip ${selectedTools.has(t)?'selected':''}" onclick="toggleTool('${t}',this)">
-      <span class="chip-dot"></span>${t}
-    </div>
-  `).join('');
-}
-
-function toggleTool(name, el) {
-  if (selectedTools.has(name)) { selectedTools.delete(name); el.classList.remove('selected'); }
-  else { selectedTools.add(name); el.classList.add('selected'); }
-}
-
 // ─── Tools page ────────────────────────────────────────────────────────────
 function buildToolsPage() {
   const grid = document.getElementById('tools-grid');
@@ -1204,6 +1193,8 @@ async function launchScan() {
 
   if (!repo_path && !repo_url) { showHint('Provide a repo path or URL'); return; }
   if (!repo_url && !config_path) { showHint('Config path is required for local repo scans'); return; }
+  // Tools are resolved server-side from the repo's vulnreach.yaml (auto-discovered)
+  // or the built-in default config — the UI no longer selects tools.
 
   const btn = document.getElementById('launch-btn');
   btn.disabled = true;
@@ -1214,7 +1205,6 @@ async function launchScan() {
   try {
     const body = {
       config_path,
-      tools: [...selectedTools],
       ...(repo_path ? { repo_path } : {}),
       ...(repo_url  ? { repo_url  } : {}),
     };
@@ -1234,8 +1224,6 @@ async function launchScan() {
 
 function resetForm() {
   ['f-repo-path','f-repo-url','f-config-path'].forEach(id => document.getElementById(id).value='');
-  selectedTools = new Set(['trivy','tainter','python_reachability']);
-  buildToolChips();
   hideProgress();
 }
 
@@ -1387,9 +1375,28 @@ function setTab(name, el) {
 }
 
 function renderPanelOverview(scan) {
-  const failedBanner = scan.failed_tools && scan.failed_tools.length
+  // Tools actually used are derived server-side from real agent execution
+  // (analysis_coverage), reflecting the repo's auto-discovered config — not a
+  // UI selection. Fall back to the metadata tool list for older/in-flight scans.
+  const cov       = scan.analysis_coverage || {};
+  const ran       = cov.tools_ran || [];
+  const skipped   = cov.tools_skipped || {};   // { tool: reason }
+  const errored   = cov.tools_errored || {};   // { tool: error }
+  const skippedKeys = Object.keys(skipped);
+  const erroredKeys = Object.keys(errored);
+
+  const toolsHtml = ran.length || skippedKeys.length || erroredKeys.length
+    ? [
+        ...ran.map(t => `<span class="tool-state tool-state--ran" title="ran">${escHtml(t)}</span>`),
+        ...skippedKeys.map(t => `<span class="tool-state tool-state--skipped" title="skipped: ${escHtml(skipped[t])}">${escHtml(t)} · skipped</span>`),
+        ...erroredKeys.map(t => `<span class="tool-state tool-state--errored" title="error: ${escHtml(errored[t])}">${escHtml(t)} · error</span>`),
+      ].join(' ')
+    : ((scan.tools||[]).join(', ') || '—');
+
+  const degradedKeys = [...skippedKeys, ...erroredKeys];
+  const failedBanner = degradedKeys.length
     ? `<div style="margin-top:1rem;padding:0.6rem 0.75rem;background:var(--amber-dim);border:1px solid #f5a62330;border-radius:4px;font-size:0.7rem;color:var(--amber)">
-        ⚠ ${scan.failed_tools.length} tool(s) skipped: <strong>${scan.failed_tools.join(', ')}</strong> — results may be incomplete
+        ⚠ ${degradedKeys.length} tool(s) did not contribute: <strong>${degradedKeys.join(', ')}</strong> — results may be incomplete
       </div>`
     : '';
 
@@ -1399,7 +1406,7 @@ function renderPanelOverview(scan) {
       <div class="meta-item"><div class="meta-key">Status</div><div class="meta-val"><span class="badge-status ${scan.status||'pending'}"><span class="s-dot"></span>${scan.status||'—'}</span></div></div>
       <div class="meta-item"><div class="meta-key">Repository</div><div class="meta-val">${scan.repo_path||scan.repo_url||'—'}</div></div>
       <div class="meta-item"><div class="meta-key">Started</div><div class="meta-val">${fmtDate(scan.started_at)||'—'}</div></div>
-      <div class="meta-item"><div class="meta-key">Tools</div><div class="meta-val">${(scan.tools||[]).join(', ')||'—'}</div></div>
+      <div class="meta-item"><div class="meta-key">Tools used</div><div class="meta-val">${toolsHtml}</div></div>
       <div class="meta-item"><div class="meta-key">Packages</div><div class="meta-val">${pkgSummaryHtml(scan.pkg_count, scan.sev_breakdown, scan.status)}</div></div>
     </div>
     ${failedBanner}
@@ -1983,3 +1990,129 @@ if (typeof mermaid !== 'undefined') {
 document.addEventListener('keydown', e => {
   if (e.key === 'Escape') { closeExplainModal(); closeGraphModal(); }
 });
+
+// ─── Connectors ────────────────────────────────────────────────────────────
+
+const _CONNECTOR_IDS = ['slack', 'jira'];
+
+async function initConnectors() {
+  for (const id of _CONNECTOR_IDS) _setConnectorHint(id, '');
+  try {
+    const data = await apiFetch('/connectors');
+    _CONNECTOR_IDS.forEach(id => _applyConnectorState(id, data[id] || {}));
+  } catch (e) {
+    _CONNECTOR_IDS.forEach(id => _setConnectorHint(id, 'Could not load connector state.'));
+  }
+}
+
+function _applyConnectorState(id, state) {
+  const connected = state.connected === true;
+  const badge = document.getElementById(`${id}-status-badge`);
+  const testBtn = document.getElementById(`${id}-test-btn`);
+  const discBtn = document.getElementById(`${id}-disconnect-btn`);
+
+  if (badge) {
+    badge.textContent = connected ? 'Connected' : 'Disconnected';
+    badge.className = `connector-badge connector-badge--${connected ? 'connected' : 'disconnected'}`;
+  }
+  if (testBtn) testBtn.style.display = connected ? '' : 'none';
+  if (discBtn) discBtn.style.display = connected ? '' : 'none';
+
+  // Populate non-secret fields; never pre-fill secrets
+  if (id === 'slack') {
+    const ch = document.getElementById('slack-channel');
+    if (ch && state.channel) ch.value = state.channel;
+  }
+  if (id === 'jira') {
+    const url = document.getElementById('jira-base-url');
+    const email = document.getElementById('jira-email');
+    const proj = document.getElementById('jira-project-key');
+    if (url && state.base_url) url.value = state.base_url;
+    if (email && state.email) email.value = state.email;
+    if (proj && state.project_key) proj.value = state.project_key;
+  }
+}
+
+function _setConnectorHint(id, msg, isError) {
+  const el = document.getElementById(`${id}-hint`);
+  if (!el) return;
+  el.textContent = msg;
+  el.style.color = isError ? 'var(--red)' : 'var(--text-dim)';
+}
+
+async function saveConnector(id) {
+  const btn = document.getElementById(`${id}-save-btn`);
+  _setConnectorHint(id, '');
+
+  let body = {};
+  if (id === 'slack') {
+    const webhookUrl = document.getElementById('slack-webhook-url').value.trim();
+    const channel    = document.getElementById('slack-channel').value.trim();
+    if (!webhookUrl) { _setConnectorHint(id, 'Webhook URL is required.', true); return; }
+    body = { webhook_url: webhookUrl, channel };
+  } else if (id === 'jira') {
+    const baseUrl    = document.getElementById('jira-base-url').value.trim();
+    const email      = document.getElementById('jira-email').value.trim();
+    const apiToken   = document.getElementById('jira-api-token').value.trim();
+    const projectKey = document.getElementById('jira-project-key').value.trim();
+    if (!baseUrl)    { _setConnectorHint(id, 'Base URL is required.', true); return; }
+    if (!email)      { _setConnectorHint(id, 'Email is required.', true); return; }
+    if (!apiToken)   { _setConnectorHint(id, 'API token is required.', true); return; }
+    if (!projectKey) { _setConnectorHint(id, 'Project key is required.', true); return; }
+    body = { base_url: baseUrl, email, api_token: apiToken, project_key: projectKey };
+  }
+
+  btn.disabled = true;
+  btn.textContent = 'Saving…';
+  try {
+    const data = await apiFetch(`/connectors/${id}`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
+    _applyConnectorState(id, data);
+    // Clear secret fields after successful save — they must not linger in the DOM
+    if (id === 'slack') document.getElementById('slack-webhook-url').value = '';
+    if (id === 'jira')  document.getElementById('jira-api-token').value = '';
+    _setConnectorHint(id, 'Saved.');
+    setTimeout(() => _setConnectorHint(id, ''), 3000);
+  } catch (e) {
+    _setConnectorHint(id, e.message || 'Save failed.', true);
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Save';
+  }
+}
+
+async function testConnector(id) {
+  _setConnectorHint(id, 'Sending test…');
+  try {
+    await apiFetch(`/connectors/${id}/test`, { method: 'POST' });
+    _setConnectorHint(id, 'Test sent successfully.');
+    setTimeout(() => _setConnectorHint(id, ''), 4000);
+  } catch (e) {
+    _setConnectorHint(id, e.message || 'Test failed.', true);
+  }
+}
+
+async function disconnectConnector(id) {
+  if (!confirm(`Remove the ${id.charAt(0).toUpperCase() + id.slice(1)} connector? This cannot be undone.`)) return;
+  _setConnectorHint(id, 'Disconnecting…');
+  try {
+    await apiFetch(`/connectors/${id}`, { method: 'DELETE' });
+    _applyConnectorState(id, { connected: false });
+    // Clear all fields for this connector
+    if (id === 'slack') {
+      document.getElementById('slack-webhook-url').value = '';
+      document.getElementById('slack-channel').value = '';
+    }
+    if (id === 'jira') {
+      ['jira-base-url','jira-email','jira-api-token','jira-project-key'].forEach(f => {
+        document.getElementById(f).value = '';
+      });
+    }
+    _setConnectorHint(id, 'Disconnected.');
+    setTimeout(() => _setConnectorHint(id, ''), 3000);
+  } catch (e) {
+    _setConnectorHint(id, e.message || 'Disconnect failed.', true);
+  }
+}

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -25,6 +25,7 @@
       <div id="_p-page-settings"></div>
       <div id="_p-page-inventory"></div>
       <div id="_p-page-findings"></div>
+      <div id="_p-page-connectors"></div>
     </main>
   </div>
 </div>

--- a/dashboard/partials/page-connectors.html
+++ b/dashboard/partials/page-connectors.html
@@ -1,0 +1,148 @@
+      <!-- Page: Connectors -->
+      <div id="page-connectors" style="display:none">
+        <div class="page-header">
+          <div>
+            <div class="page-title">Connectors</div>
+            <div class="page-subtitle">Connect external services to receive alerts and create tickets</div>
+          </div>
+        </div>
+
+        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(340px,1fr));gap:1.25rem">
+
+          <!-- Slack Card -->
+          <div class="scan-form-card" id="connector-slack-card">
+            <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1rem">
+              <div style="width:36px;height:36px;border-radius:8px;background:var(--surface);border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-size:1.1rem">
+                <i class="fab fa-slack" style="color:#4a154b"></i>
+              </div>
+              <div style="flex:1">
+                <div style="font-family:var(--sans);font-size:0.95rem;font-weight:600;color:var(--text)">Slack</div>
+                <div style="font-size:0.72rem;color:var(--text-dim)">Post findings and scan alerts to a channel</div>
+              </div>
+              <span id="slack-status-badge" class="connector-badge connector-badge--disconnected">Disconnected</span>
+            </div>
+
+            <div id="slack-form">
+              <div class="form-group" style="margin-bottom:0.75rem">
+                <label class="form-label">Incoming Webhook URL
+                  <span style="color:var(--text-dim);font-weight:400;margin-left:0.25rem">(write-only)</span>
+                </label>
+                <input
+                  class="form-input"
+                  id="slack-webhook-url"
+                  type="password"
+                  placeholder="https://hooks.slack.com/services/…"
+                  autocomplete="new-password"
+                  maxlength="500"
+                />
+                <div style="font-size:0.7rem;color:var(--text-dim);margin-top:0.35rem">
+                  Create a webhook at <span style="color:var(--blue)">api.slack.com/apps</span> → Incoming Webhooks. Never share this URL.
+                </div>
+              </div>
+
+              <div class="form-group" style="margin-bottom:1rem">
+                <label class="form-label">Default Channel <span style="color:var(--text-dim);font-weight:400">(optional override)</span></label>
+                <input
+                  class="form-input"
+                  id="slack-channel"
+                  type="text"
+                  placeholder="#security-alerts"
+                  maxlength="100"
+                />
+              </div>
+
+              <div style="display:flex;gap:0.5rem;align-items:center">
+                <button class="btn-primary" id="slack-save-btn" onclick="saveConnector('slack')">Save</button>
+                <button class="btn-secondary" id="slack-test-btn" onclick="testConnector('slack')" style="display:none">Send Test</button>
+                <button class="btn-secondary" id="slack-disconnect-btn" onclick="disconnectConnector('slack')" style="display:none;color:var(--red);border-color:var(--red)">Disconnect</button>
+                <span id="slack-hint" style="font-size:0.72rem;color:var(--text-dim)"></span>
+              </div>
+            </div>
+          </div>
+
+          <!-- JIRA Card -->
+          <div class="scan-form-card" id="connector-jira-card">
+            <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:1rem">
+              <div style="width:36px;height:36px;border-radius:8px;background:var(--surface);border:1px solid var(--border);display:flex;align-items:center;justify-content:center;font-size:1.1rem">
+                <i class="fab fa-jira" style="color:#0052cc"></i>
+              </div>
+              <div style="flex:1">
+                <div style="font-family:var(--sans);font-size:0.95rem;font-weight:600;color:var(--text)">Jira</div>
+                <div style="font-size:0.72rem;color:var(--text-dim)">Auto-create tickets for reachable vulnerabilities</div>
+              </div>
+              <span id="jira-status-badge" class="connector-badge connector-badge--disconnected">Disconnected</span>
+            </div>
+
+            <div id="jira-form">
+              <div class="form-group" style="margin-bottom:0.75rem">
+                <label class="form-label">Jira Base URL</label>
+                <input
+                  class="form-input"
+                  id="jira-base-url"
+                  type="url"
+                  placeholder="https://yourorg.atlassian.net"
+                  maxlength="256"
+                />
+              </div>
+
+              <div class="form-group" style="margin-bottom:0.75rem">
+                <label class="form-label">Account Email</label>
+                <input
+                  class="form-input"
+                  id="jira-email"
+                  type="email"
+                  placeholder="you@yourorg.com"
+                  maxlength="254"
+                  autocomplete="username"
+                />
+              </div>
+
+              <div class="form-group" style="margin-bottom:0.75rem">
+                <label class="form-label">API Token
+                  <span style="color:var(--text-dim);font-weight:400;margin-left:0.25rem">(write-only)</span>
+                </label>
+                <input
+                  class="form-input"
+                  id="jira-api-token"
+                  type="password"
+                  placeholder="Generate at id.atlassian.com/manage-profile/security/api-tokens"
+                  autocomplete="new-password"
+                  maxlength="500"
+                />
+                <div style="font-size:0.7rem;color:var(--text-dim);margin-top:0.35rem">
+                  Tokens are stored server-side and never returned to the browser.
+                </div>
+              </div>
+
+              <div class="form-group" style="margin-bottom:1rem">
+                <label class="form-label">Default Project Key</label>
+                <input
+                  class="form-input"
+                  id="jira-project-key"
+                  type="text"
+                  placeholder="SEC"
+                  maxlength="32"
+                />
+              </div>
+
+              <div style="display:flex;gap:0.5rem;align-items:center">
+                <button class="btn-primary" id="jira-save-btn" onclick="saveConnector('jira')">Save</button>
+                <button class="btn-secondary" id="jira-test-btn" onclick="testConnector('jira')" style="display:none">Test Connection</button>
+                <button class="btn-secondary" id="jira-disconnect-btn" onclick="disconnectConnector('jira')" style="display:none;color:var(--red);border-color:var(--red)">Disconnect</button>
+                <span id="jira-hint" style="font-size:0.72rem;color:var(--text-dim)"></span>
+              </div>
+            </div>
+          </div>
+
+        </div>
+
+        <!-- Info callout -->
+        <div style="margin-top:1.25rem;padding:0.85rem 1rem;border:1px solid var(--border);border-radius:8px;background:var(--surface);display:flex;gap:0.75rem;align-items:flex-start">
+          <i class="fas fa-circle-info" style="color:var(--blue);margin-top:0.1rem;flex-shrink:0"></i>
+          <div style="font-size:0.75rem;color:var(--text-dim);line-height:1.6">
+            Credentials are stored server-side and <strong style="color:var(--text)">never returned to the browser</strong> after saving.
+            Existing values are shown as <code style="color:var(--green)">***</code> — re-enter only when rotating.
+            Only admins can view or modify connectors.
+          </div>
+        </div>
+      </div>

--- a/dashboard/partials/page-new.html
+++ b/dashboard/partials/page-new.html
@@ -23,11 +23,6 @@
             </div>
           </div>
 
-          <div class="form-group">
-            <label class="form-label">Tools</label>
-            <div class="tools-grid" id="tool-chips"></div>
-          </div>
-
           <div class="form-actions">
             <button class="btn-primary" id="launch-btn" onclick="launchScan()">
               ▶ Launch Scan

--- a/dashboard/partials/sidebar.html
+++ b/dashboard/partials/sidebar.html
@@ -29,6 +29,10 @@
           <span class="nav-icon"><i class="fas fa-toolbox"></i></span>
           <span class="nav-text">Tools</span>
         </div>
+        <div class="nav-item" onclick="setPage('connectors')">
+          <span class="nav-icon"><i class="fas fa-plug"></i></span>
+          <span class="nav-text">Connectors</span>
+        </div>
         <div class="nav-item" onclick="setPage('api')">
           <span class="nav-icon"><i class="fas fa-key"></i></span>
           <span class="nav-text">API Access</span>

--- a/labs/ebpf-e2e-java/vulnreach.yaml
+++ b/labs/ebpf-e2e-java/vulnreach.yaml
@@ -16,3 +16,7 @@ scan:
 risk:
   exposure: public
   data_sensitivity: high
+
+
+notifications:
+  slack: true

--- a/storage/repository.py
+++ b/storage/repository.py
@@ -69,6 +69,18 @@ class StorageRepository(ABC):
     def delete_scan(self, scan_id: str) -> bool:
         raise NotImplementedError
 
+    @abstractmethod
+    def get_connector(self, connector_id: str) -> Optional[Dict[str, Any]]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def upsert_connector(self, connector_id: str, config: Dict[str, Any]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_connector(self, connector_id: str) -> bool:
+        raise NotImplementedError
+
 
 class PostgresRepository(StorageRepository):
     def __init__(self, dsn: Optional[str] = None) -> None:
@@ -333,6 +345,13 @@ class PostgresRepository(StorageRepository):
             "CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(user_id);",
             "CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash);",
             "CREATE INDEX IF NOT EXISTS idx_api_keys_key_prefix ON api_keys(key_prefix);",
+            """
+            CREATE TABLE IF NOT EXISTS connectors (
+                id TEXT PRIMARY KEY,
+                config JSONB NOT NULL DEFAULT '{}'::jsonb,
+                updated_at TIMESTAMPTZ DEFAULT NOW()
+            );
+            """,
         ]
         with self._conn() as conn:
             with conn.cursor() as cur:
@@ -753,6 +772,34 @@ class PostgresRepository(StorageRepository):
                     "DELETE FROM api_keys WHERE id = %s AND user_id = %s",
                     (key_id, user_id),
                 )
+                return cur.rowcount > 0
+
+    # ── Connectors ────────────────────────────────────────────────────
+
+    def get_connector(self, connector_id: str) -> Optional[Dict[str, Any]]:
+        with self._conn() as conn:
+            with conn.cursor(cursor_factory=RealDictCursor) as cur:
+                cur.execute("SELECT config FROM connectors WHERE id = %s", (connector_id,))
+                row = cur.fetchone()
+        if not row:
+            return None
+        cfg = row["config"]
+        return dict(cfg) if cfg else {}
+
+    def upsert_connector(self, connector_id: str, config: Dict[str, Any]) -> None:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO connectors (id, config, updated_at)
+                       VALUES (%s, %s, NOW())
+                       ON CONFLICT (id) DO UPDATE SET config = EXCLUDED.config, updated_at = NOW()""",
+                    (connector_id, Json(config)),
+                )
+
+    def delete_connector(self, connector_id: str) -> bool:
+        with self._conn() as conn:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM connectors WHERE id = %s", (connector_id,))
                 return cur.rowcount > 0
 
     def _convert_correlation(self, row: Dict[str, Any]) -> Dict[str, Any]:

--- a/storage/sqlite_repository.py
+++ b/storage/sqlite_repository.py
@@ -162,6 +162,12 @@ class SQLiteRepository(StorageRepository):
         CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys(user_id);
         CREATE INDEX IF NOT EXISTS idx_api_keys_key_hash ON api_keys(key_hash);
         CREATE INDEX IF NOT EXISTS idx_api_keys_key_prefix ON api_keys(key_prefix);
+
+        CREATE TABLE IF NOT EXISTS connectors (
+            id TEXT PRIMARY KEY,
+            config TEXT NOT NULL DEFAULT '{}',
+            updated_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+        );
         """
         with self._conn() as conn:
             conn.executescript(ddl)
@@ -511,6 +517,31 @@ class SQLiteRepository(StorageRepository):
                 "DELETE FROM api_keys WHERE id=? AND user_id=?",
                 (key_id, user_id),
             )
+        return cur.rowcount > 0
+
+    # ── Connectors ────────────────────────────────────────────────────
+
+    def get_connector(self, connector_id: str) -> Optional[Dict[str, Any]]:
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT config FROM connectors WHERE id=?", (connector_id,)
+            ).fetchone()
+        if not row:
+            return None
+        return _p(row["config"]) or {}
+
+    def upsert_connector(self, connector_id: str, config: Dict[str, Any]) -> None:
+        with self._conn() as conn:
+            conn.execute(
+                """INSERT INTO connectors (id, config, updated_at)
+                   VALUES (?, ?, ?)
+                   ON CONFLICT(id) DO UPDATE SET config=excluded.config, updated_at=excluded.updated_at""",
+                (connector_id, _j(config), _now_iso()),
+            )
+
+    def delete_connector(self, connector_id: str) -> bool:
+        with self._conn() as conn:
+            cur = conn.execute("DELETE FROM connectors WHERE id=?", (connector_id,))
         return cur.rowcount > 0
 
     # ── Shared helpers ────────────────────────────────────────────────


### PR DESCRIPTION
- Remove Tools chip section from New Scan UI; tools now come from the repo's auto-discovered vulnreach.yaml (or default_config fallback)
- Scan overview "Tools used" now renders from analysis_coverage — green = ran, grey = skipped, amber = errored (with reasons on hover)
- SlackNotifier: per-status headers and bodies for completed, blocked, partial, failed, cancelled, timeout, and error
- Orchestrator wraps execute_scan in try/except to catch CancelledError, TimeoutError, and unhandled exceptions — each fires the matching Slack notification and updates scan status accordingly
- Pass failed_tools / fatal_tools through to the notifier so partial and failed messages list which tools degraded

## Summary by Sourcery

Remove UI-level tool selection in favour of config-driven tooling, add configurable outbound connectors (Slack, Jira) with per-scan Slack notifications, and surface actual tool execution state in scan overviews.

New Features:
- Introduce Slack and Jira connectors with admin-only APIs and a dashboard page to configure, test, and disconnect them.
- Add per-scan notification settings in vulnreach configuration to control Slack (and future Jira) notifications.
- Send Slack notifications for scan completion and failure scenarios with status-specific messaging, including degraded tool details where applicable.

Enhancements:
- Resolve scan tools exclusively from the resolved configuration and analysis coverage instead of user-selected UI chips.
- Display tool execution status (ran, skipped with reason, errored) in the scan overview, with a degraded-results banner when tools do not contribute.
- Ensure orchestrator-level error handling distinguishes cancelled, timeout, and unhandled error cases while updating scan status and triggering matching notifications.

Build:
- Extend Postgres and SQLite schemas and repositories to persist generic connector configurations.